### PR TITLE
Point repository links to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Specific deployment of the [umb-template](https://github.com/HEP-FCC/umb-template) for the metadata of the FCC physics datasets.
 
+## 📦 Repository
+
+The canonical repository is on GitHub: [HEP-FCC/fcc-physics-events](https://github.com/HEP-FCC/fcc-physics-events). It is pull-mirrored to [CERN GitLab](https://gitlab.cern.ch/hep-fcc/fcc-physics-events), which runs CI/CD. Please open issues and merge requests on GitHub.
+
 ## 🚀 Deployment
 
 This application is automatically deployed after any change to the master branch. Firstly the web application is packaged to 2 docker images called fcc-physics-events-backend and fcc-physics-events-frontend. They are pushed to the CERN's docker registry in the [fcc-physics-events repository](https://registry.cern.ch/harbor/projects/3847/repositories). Then it is deployed to the CERN's PAAS OpenShift cluster in the [fcc-physics-events namespace](https://paas.cern.ch/topology/ns/fcc-physics-events).

--- a/frontend/components/ContactModal.vue
+++ b/frontend/components/ContactModal.vue
@@ -57,7 +57,7 @@
                     <div class="flex items-center space-x-2">
                         <UIcon name="i-heroicons-code-bracket" class="text-secondary-500" />
                         <a
-                            href="https://gitlab.cern.ch/hep-fcc/fcc-physics-events"
+                            href="https://github.com/HEP-FCC/fcc-physics-events"
                             target="_blank"
                             rel="noopener noreferrer"
                             class="text-deep-blue-600 hover:text-deep-blue-900 transition-colors"


### PR DESCRIPTION
GitHub is now the canonical home for this repo, with GitLab pull-mirroring it for CI. Update the README and the Contact modal's Code Repository link accordingly.