### PR TITLE
feat: add share link button and auto-expand single search results

### DIFF
--- a/backend/app/utils/gclql_query_parser_utils.py
+++ b/backend/app/utils/gclql_query_parser_utils.py
@@ -53,8 +53,8 @@ QUERY_LANGUAGE_GRAMMAR = r"""
     AND.2: "AND"
     OR.2: "OR"
     NOT.2: "NOT"
+    UUID.2: /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/
     IDENTIFIER: /[a-zA-Z_][a-zA-Z0-9_-]*/
-    UUID: /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/
     ASTERISK: "*"
     OP: "=" | "!=" | ">" | "<" | ">=" | "<=" | ":" | "!:" | "=~" | "!~" | "#"
     QUOTED_STRING: /"[^"]*"/ | /'[^']*'/
@@ -448,6 +448,12 @@ class SqlTranslator:
             0
         ] == "last_edited_at" or sql_field.endswith("last_edited_at")
 
+        # Special handling for UUID fields
+        is_uuid_field = (
+            node.field.parts[0] == "uuid"
+            or sql_field.endswith(".uuid")
+)
+
         self.param_index += 1
         placeholder = f"${self.param_index}"
 
@@ -467,7 +473,7 @@ class SqlTranslator:
             else:
                 # For string values, use case-insensitive exact match (ILIKE)
                 # For numeric/date values, use exact match (=)
-                if isinstance(value, str) and not is_last_edited_at:
+                if isinstance(value, str) and not is_last_edited_at and not is_uuid_field:
                     sql_op, param_value = "ILIKE", value
                 else:
                     sql_op, param_value = "=", value
@@ -487,7 +493,7 @@ class SqlTranslator:
         elif op == "!=":
             # For string values, use case-insensitive not equal (NOT ... ILIKE)
             # For numeric/date values, use exact not equal (!=)
-            if isinstance(value, str) and not is_last_edited_at:
+            if isinstance(value, str) and not is_last_edited_at and not is_uuid_field:
                 # Use NOT (field ILIKE value) for case-insensitive inequality
                 sql_op, param_value = "NOT_ILIKE", value
             else:

--- a/frontend/components/ContactModal.vue
+++ b/frontend/components/ContactModal.vue
@@ -57,7 +57,7 @@
                     <div class="flex items-center space-x-2">
                         <UIcon name="i-heroicons-code-bracket" class="text-secondary-500" />
                         <a
-                            href="https://gitlab.cern.ch/hep-fcc/fcc-physics-events"
+                            href="https://github.com/HEP-FCC/fcc-physics-events"
                             target="_blank"
                             rel="noopener noreferrer"
                             class="text-deep-blue-600 hover:text-deep-blue-900 transition-colors"

--- a/frontend/components/ContactModal.vue
+++ b/frontend/components/ContactModal.vue
@@ -51,7 +51,7 @@
                     </div>
                 </div>
 
-                <!-- GitHub Source -->
+                <!-- Code Repository -->
                 <div class="space-y-2">
                     <h3 class="text-sm font-medium text-deep-blue-900">Source Code</h3>
                     <div class="flex items-center space-x-2">
@@ -62,7 +62,7 @@
                             rel="noopener noreferrer"
                             class="text-deep-blue-600 hover:text-deep-blue-900 transition-colors"
                         >
-                            GitHub Repository
+                            Visit Repository
                         </a>
                     </div>
                 </div>

--- a/frontend/components/ContactModal.vue
+++ b/frontend/components/ContactModal.vue
@@ -51,18 +51,18 @@
                     </div>
                 </div>
 
-                <!-- Code Repository -->
+                <!-- GitHub Source -->
                 <div class="space-y-2">
-                    <h3 class="text-sm font-medium text-deep-blue-900">Code Repository</h3>
+                    <h3 class="text-sm font-medium text-deep-blue-900">Source Code</h3>
                     <div class="flex items-center space-x-2">
                         <UIcon name="i-heroicons-code-bracket" class="text-secondary-500" />
                         <a
-                            href="https://github.com/HEP-FCC/fcc-physics-events"
+                            href="https://gitlab.cern.ch/hep-fcc/fcc-physics-events"
                             target="_blank"
                             rel="noopener noreferrer"
                             class="text-deep-blue-600 hover:text-deep-blue-900 transition-colors"
                         >
-                            Visit Repository
+                            GitHub Repository
                         </a>
                     </div>
                 </div>

--- a/frontend/components/entities/EntityList.vue
+++ b/frontend/components/entities/EntityList.vue
@@ -250,4 +250,26 @@ function handleEntityKeydown(event: KeyboardEvent, entityId: number): void {
             break;
     }
 }
+
+watch(() => props.entities, (newEntities: Entity[]) => {
+    // If the list finishes loading and there is exactly 1 result...
+    if (newEntities && newEntities.length === 1) {
+        
+        const singleEntityId = getEntityId(newEntities[0]);
+        
+        // Ensure it's valid and not already open
+        if (singleEntityId !== -1 && !isMetadataExpanded(singleEntityId)) {
+            
+            // Wait 50 milliseconds to let the parent component finish its own resets
+            
+            setTimeout(() => {
+                // Double check it's still closed just to be safe
+                if (!isMetadataExpanded(singleEntityId)) {
+                    toggleMetadata(singleEntityId);
+                }
+            }, 50);
+            
+        }
+    }
+}, { immediate: true });
 </script>

--- a/frontend/components/entities/EntityMetadata.vue
+++ b/frontend/components/entities/EntityMetadata.vue
@@ -419,10 +419,9 @@ const { isAuthenticated } = useAuth();
 const { mainTableDisplayName } = useAppConfiguration();
 
 const myHttpsLink = computed(() => {
-    // Check if the UUID exists on the entity
-    if (!props.entity?.uuid) return '';
+
     // Construct the link (Replace with your actual domain/path if needed)
-    return `https://fcc-physics-events.web.cern.ch/?q=${props.entity.uuid}`;
+    return `https://fcc-physics-events.web.cern.ch/?q=uuid%3D${props.entity.uuid}`;
 });
 
 const copyLinkToClipboard = () => {

--- a/frontend/components/entities/EntityMetadata.vue
+++ b/frontend/components/entities/EntityMetadata.vue
@@ -129,6 +129,22 @@
                         </UButton>
                     </UTooltip>
 
+                    <!-- Link button -->
+                    <UTooltip
+                        text="Copy link to this record"
+                        :popper="{ placement: 'top' }"
+                    >
+                        <UButton
+                            icon="i-heroicons-link"
+                            class="text-neutral-600 cursor-pointer hover:text-neutral-800 hover:bg-neutral-100"
+                            variant="ghost"
+                            size="xs"
+                            @click="copyLinkToClipboard"
+                        >
+                            Link
+                        </UButton>
+                    </UTooltip>
+
                     <!-- Edit button -->
                     <UButton
                         icon="i-heroicons-pencil"
@@ -401,6 +417,18 @@ const { formatFieldName, formatSizeInGiB, copyToClipboard, isStatusField, getSta
     useUtils();
 const { isAuthenticated } = useAuth();
 const { mainTableDisplayName } = useAppConfiguration();
+
+const myHttpsLink = computed(() => {
+    // Check if the UUID exists on the entity
+    if (!props.entity?.uuid) return '';
+    // Construct the link (Replace with your actual domain/path if needed)
+    return `https://fcc-physics-events.web.cern.ch/?q=${props.entity.uuid}`;
+});
+
+const copyLinkToClipboard = () => {
+
+    copyToClipboard(myHttpsLink.value);
+};
 
 // Dynamic color system using CSS custom properties
 // Dark mode disabled for consistent mobile rendering

--- a/frontend/composables/entities/useEntitySearch.ts
+++ b/frontend/composables/entities/useEntitySearch.ts
@@ -198,7 +198,12 @@ export function useEntitySearch() {
             // For infinite scroll: use currentPage directly
             // For initial load: always start with page 1
             const pageToLoad = isInitialLoad ? 1 : scrollState.currentPage;
-            const queryToSend = searchQuery || "*";
+            // Removes "uuid=", spaces, and optional quotes before sending to API
+            const sanitizedQuery = searchQuery
+                .replace(/^uuid\s*=\s*['"]?/i, "")
+                .replace(/['"]?$/i, "")
+                .trim();
+            const queryToSend = sanitizedQuery || "*";
 
             const searchParams = {
                 query: queryToSend,

--- a/frontend/composables/entities/useEntitySearch.ts
+++ b/frontend/composables/entities/useEntitySearch.ts
@@ -198,12 +198,7 @@ export function useEntitySearch() {
             // For infinite scroll: use currentPage directly
             // For initial load: always start with page 1
             const pageToLoad = isInitialLoad ? 1 : scrollState.currentPage;
-            // Removes "uuid=", spaces, and optional quotes before sending to API
-            const sanitizedQuery = searchQuery
-                .replace(/^uuid\s*=\s*['"]?/i, "")
-                .replace(/['"]?$/i, "")
-                .trim();
-            const queryToSend = sanitizedQuery || "*";
+            const queryToSend = searchQuery || "*";
 
             const searchParams = {
                 query: queryToSend,


### PR DESCRIPTION
**What this PR does:**
- Adds a "Link" button to the `EntityMetadata` component that automatically generates and copies a direct URL to the dataset (e.g., `/?q=[uuid]`).
- Hides the full URL text to keep the UI clean, matching the design of the mobile UUID button.
- Updates the parent list component to automatically expand a dataset's metadata box if a search query returns exactly 1 result.