### PR TITLE
Feature/config url generator cards

### DIFF
--- a/backend/app/storage/database_modules/data_import_module.py
+++ b/backend/app/storage/database_modules/data_import_module.py
@@ -321,6 +321,11 @@ async def _process_single_entity(
 
     # Get metadata and create the main entity
     metadata_dict = entity_data.get_all_metadata()
+    config_url = _build_config_url(
+        entity_name, entity_data.campaign, entity_data.accelerator
+    )
+    if config_url:
+        metadata_dict = {**metadata_dict, "config-url": config_url}
     await _create_main_entity_with_conflict_resolution(
         conn, entity_name, metadata_dict, foreign_key_ids, main_table
     )
@@ -396,6 +401,72 @@ def _generate_entity_name(entity_data: BaseEntityData, idx: int) -> str:
         )
     return entity_name
 
+_GITHUB_BASE = "https://github.com/HEP-FCC/FCC-config/blob"
+_GENERATOR_MAPPING = {
+    "wzp6": ("Whizard", ".sin"),
+    "wz3p6": ("Whizard", ".sin"),
+    "p8": ("Pythia8", ".cmd"),
+    "pythia8": ("Pythia8", ".cmd"),
+    "kkmc": ("KKMC", ".input"),
+}
+_ACCELERATOR_SEGMENT = {
+    "fcc-ee": "FCCee",
+}
+_WHIZARD_VERSION = {
+    "winter2023": "v3.0.3",
+    "pre_summer2026": "v3.1.5",
+}
+
+
+def _build_config_url(
+    dataset_name: str | None,
+    campaign: str | None,
+    accelerator: str | None,
+) -> str | None:
+    if not dataset_name or dataset_name.startswith("unnamed_entity_"):
+        return None
+    if not campaign or not campaign.strip():
+        return None
+    if not accelerator or not accelerator.strip():
+        return None
+
+    accel_seg = _ACCELERATOR_SEGMENT.get(accelerator.strip().lower())
+    if accel_seg is None:
+        logger.warning(
+            f"No config-path segment for accelerator '{accelerator}'; "
+            f"config-url skipped for '{dataset_name}'."
+        )
+        return None
+
+    last_segment = dataset_name.rstrip("/").rsplit("/", 1)[-1]
+    token = last_segment.split("_", 1)[0].lower()
+    mapping = _GENERATOR_MAPPING.get(token)
+    if mapping is None:
+        logger.warning(
+            f"Unrecognized generator prefix '{token}' in '{dataset_name}'; "
+            "config-url skipped."
+        )
+        return None
+    folder, ext = mapping
+    branch = campaign.strip()
+
+    if folder == "Whizard":
+        version = _WHIZARD_VERSION.get(branch)
+        if version is None:
+            logger.warning(
+                f"No Whizard version mapping for campaign '{branch}'; "
+                f"config-url skipped for '{dataset_name}'."
+            )
+            return None
+        return (
+            f"{_GITHUB_BASE}/{branch}/{accel_seg}/Generator/"
+            f"{folder}/{version}/{last_segment}{ext}"  # was dataset_name
+        )
+
+    return (
+        f"{_GITHUB_BASE}/{branch}/{accel_seg}/Generator/"
+        f"{folder}/{last_segment}{ext}"  # was dataset_name
+    )
 
 async def _get_navigation_entity_structure(
     database: "Database", conn: asyncpg.Connection

--- a/backend/app/storage/database_modules/data_import_module.py
+++ b/backend/app/storage/database_modules/data_import_module.py
@@ -32,6 +32,22 @@ if TYPE_CHECKING:
 
 logger = get_logger()
 
+_GITHUB_BASE = "https://github.com/HEP-FCC/FCC-config/blob"
+_GENERATOR_MAPPING = {
+    "wzp6": ("Whizard", ".sin"),
+    "wz3p6": ("Whizard", ".sin"),
+    "p8": ("Pythia8", ".cmd"),
+    "pythia8": ("Pythia8", ".cmd"),
+    "kkmc": ("KKMC", ".input"),
+}
+_ACCELERATOR_SEGMENT = {
+    "fcc-ee": "FCCee",
+}
+_WHIZARD_VERSION = {
+    "winter2023": "v3.0.3",
+    "pre_summer2026": "v3.1.5",
+}
+
 
 # NOTE: This function can be changed by users
 async def import_data(database: "Database", json_content: bytes) -> None:
@@ -416,6 +432,57 @@ _WHIZARD_VERSION = {
     "winter2023": "v3.0.3",
     "pre_summer2026": "v3.1.5",
 }
+
+
+def _build_config_url(
+    dataset_name: str | None,
+    campaign: str | None,
+    accelerator: str | None,
+) -> str | None:
+    if not dataset_name or dataset_name.startswith("unnamed_entity_"):
+        return None
+    if not campaign or not campaign.strip():
+        return None
+    if not accelerator or not accelerator.strip():
+        return None
+
+    accel_seg = _ACCELERATOR_SEGMENT.get(accelerator.strip().lower())
+    if accel_seg is None:
+        logger.warning(
+            f"No config-path segment for accelerator '{accelerator}'; "
+            f"config-url skipped for '{dataset_name}'."
+        )
+        return None
+
+    last_segment = dataset_name.rstrip("/").rsplit("/", 1)[-1]
+    token = last_segment.split("_", 1)[0].lower()
+    mapping = _GENERATOR_MAPPING.get(token)
+    if mapping is None:
+        logger.warning(
+            f"Unrecognized generator prefix '{token}' in '{dataset_name}'; "
+            "config-url skipped."
+        )
+        return None
+    folder, ext = mapping
+    branch = campaign.strip()
+
+    if folder == "Whizard":
+        version = _WHIZARD_VERSION.get(branch)
+        if version is None:
+            logger.warning(
+                f"No Whizard version mapping for campaign '{branch}'; "
+                f"config-url skipped for '{dataset_name}'."
+            )
+            return None
+        return (
+            f"{_GITHUB_BASE}/{branch}/{accel_seg}/Generator/"
+            f"{folder}/{version}/{last_segment}{ext}"  # was dataset_name
+        )
+
+    return (
+        f"{_GITHUB_BASE}/{branch}/{accel_seg}/Generator/"
+        f"{folder}/{last_segment}{ext}"  # was dataset_name
+    )
 
 
 def _build_config_url(

--- a/backend/app/utils/gclql_query_parser_utils.py
+++ b/backend/app/utils/gclql_query_parser_utils.py
@@ -53,8 +53,8 @@ QUERY_LANGUAGE_GRAMMAR = r"""
     AND.2: "AND"
     OR.2: "OR"
     NOT.2: "NOT"
+    UUID.2: /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/
     IDENTIFIER: /[a-zA-Z_][a-zA-Z0-9_-]*/
-    UUID: /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/
     ASTERISK: "*"
     OP: "=" | "!=" | ">" | "<" | ">=" | "<=" | ":" | "!:" | "=~" | "!~" | "#"
     QUOTED_STRING: /"[^"]*"/ | /'[^']*'/
@@ -448,6 +448,12 @@ class SqlTranslator:
             0
         ] == "last_edited_at" or sql_field.endswith("last_edited_at")
 
+        # Special handling for UUID fields
+        is_uuid_field = (
+            node.field.parts[0] == "uuid"
+            or sql_field.endswith(".uuid")
+)
+
         self.param_index += 1
         placeholder = f"${self.param_index}"
 
@@ -467,7 +473,7 @@ class SqlTranslator:
             else:
                 # For string values, use case-insensitive exact match (ILIKE)
                 # For numeric/date values, use exact match (=)
-                if isinstance(value, str) and not is_last_edited_at:
+                if isinstance(value, str) and not is_last_edited_at and not is_uuid_field:
                     sql_op, param_value = "ILIKE", value
                 else:
                     sql_op, param_value = "=", value
@@ -487,7 +493,7 @@ class SqlTranslator:
         elif op == "!=":
             # For string values, use case-insensitive not equal (NOT ... ILIKE)
             # For numeric/date values, use exact not equal (!=)
-            if isinstance(value, str) and not is_last_edited_at:
+            if isinstance(value, str) and not is_last_edited_at and not is_uuid_field:
                 # Use NOT (field ILIKE value) for case-insensitive inequality
                 sql_op, param_value = "NOT_ILIKE", value
             else:

--- a/frontend/components/ContactModal.vue
+++ b/frontend/components/ContactModal.vue
@@ -57,7 +57,7 @@
                     <div class="flex items-center space-x-2">
                         <UIcon name="i-heroicons-code-bracket" class="text-secondary-500" />
                         <a
-                            href="https://gitlab.cern.ch/hep-fcc/fcc-physics-events"
+                            href="https://github.com/HEP-FCC/fcc-physics-events"
                             target="_blank"
                             rel="noopener noreferrer"
                             class="text-deep-blue-600 hover:text-deep-blue-900 transition-colors"

--- a/frontend/components/ContactModal.vue
+++ b/frontend/components/ContactModal.vue
@@ -51,7 +51,7 @@
                     </div>
                 </div>
 
-                <!-- GitHub Source -->
+                <!-- Code Repository -->
                 <div class="space-y-2">
                     <h3 class="text-sm font-medium text-deep-blue-900">Source Code</h3>
                     <div class="flex items-center space-x-2">
@@ -62,7 +62,7 @@
                             rel="noopener noreferrer"
                             class="text-deep-blue-600 hover:text-deep-blue-900 transition-colors"
                         >
-                            GitHub Repository
+                            Visit Repository
                         </a>
                     </div>
                 </div>

--- a/frontend/components/ContactModal.vue
+++ b/frontend/components/ContactModal.vue
@@ -51,18 +51,18 @@
                     </div>
                 </div>
 
-                <!-- Code Repository -->
+                <!-- GitHub Source -->
                 <div class="space-y-2">
-                    <h3 class="text-sm font-medium text-deep-blue-900">Code Repository</h3>
+                    <h3 class="text-sm font-medium text-deep-blue-900">Source Code</h3>
                     <div class="flex items-center space-x-2">
                         <UIcon name="i-heroicons-code-bracket" class="text-secondary-500" />
                         <a
-                            href="https://github.com/HEP-FCC/fcc-physics-events"
+                            href="https://gitlab.cern.ch/hep-fcc/fcc-physics-events"
                             target="_blank"
                             rel="noopener noreferrer"
                             class="text-deep-blue-600 hover:text-deep-blue-900 transition-colors"
                         >
-                            Visit Repository
+                            GitHub Repository
                         </a>
                     </div>
                 </div>

--- a/frontend/components/entities/EntityList.vue
+++ b/frontend/components/entities/EntityList.vue
@@ -250,4 +250,26 @@ function handleEntityKeydown(event: KeyboardEvent, entityId: number): void {
             break;
     }
 }
+
+watch(() => props.entities, (newEntities: Entity[]) => {
+    // If the list finishes loading and there is exactly 1 result...
+    if (newEntities && newEntities.length === 1) {
+        
+        const singleEntityId = getEntityId(newEntities[0]);
+        
+        // Ensure it's valid and not already open
+        if (singleEntityId !== -1 && !isMetadataExpanded(singleEntityId)) {
+            
+            // Wait 50 milliseconds to let the parent component finish its own resets
+            
+            setTimeout(() => {
+                // Double check it's still closed just to be safe
+                if (!isMetadataExpanded(singleEntityId)) {
+                    toggleMetadata(singleEntityId);
+                }
+            }, 50);
+            
+        }
+    }
+}, { immediate: true });
 </script>

--- a/frontend/components/entities/EntityMetadata.vue
+++ b/frontend/components/entities/EntityMetadata.vue
@@ -245,14 +245,21 @@
                                             class="text-xs leading-tight break-words"
                                             :title="getUnifiedFieldValueTitle(field)"
                                         >
-                                            {{ getUnifiedDisplayValue(field) }}
+                                                <a
+                                                v-if="field.type === 'url'"
+                                                    :href="String(field.value)"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    class="text-blue-500 break-all inline-flex items-center gap-1"
+                                                    @click.stop
+                                                >{{ field.value }}<UIcon name="i-heroicons-arrow-top-right-on-square" class="w-3 h-3 shrink-0 inline" /></a>
+                                            <template v-else>{{ getUnifiedDisplayValue(field) }}</template>
                                         </div>
                                     </div>
                                 </div>
                             </template>
                         </div>
                     </div>
-
                     <!-- Desktop layout: Continuous grid flow without grouping -->
                     <div class="hidden lg:block">
                         <!-- Single continuous grid for all fields -->
@@ -349,7 +356,15 @@
                                             class="flex-1 text-xs leading-tight min-w-0 mr-2"
                                             :title="getUnifiedFieldValueTitle(field)"
                                         >
-                                            {{ getUnifiedDisplayValue(field) }}
+                                                <a
+                                                v-if="field.type === 'url'"
+                                                    :href="String(field.value)"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    class="text-blue-500 break-all inline-flex items-center gap-1"
+                                                    @click.stop
+                                                >{{ field.value }}<UIcon name="i-heroicons-arrow-top-right-on-square" class="w-3 h-3 shrink-0 inline" /></a>
+                                            <template v-else>{{ getUnifiedDisplayValue(field) }}</template>
                                         </div>
 
                                         <!-- Action buttons -->
@@ -641,6 +656,10 @@ const isLongString = (value: unknown): boolean => {
     return typeof value === "string" && value.length > 50;
 };
 
+const isUrlString = (value: unknown): boolean => {
+    return typeof value === "string" && /^https?:\/\/\S+$/.test(value.trim());
+};
+
 // Check if a string value is actually a number
 const isNumericString = (value: unknown): boolean => {
     if (typeof value !== "string") return false;
@@ -698,6 +717,8 @@ const getTypeIcon = (type: string): string => {
             return "✓";
         case "vector":
             return "<>";
+        case "url":
+            return "🔗";
         case "longString":
             return "A";
         default: // shortString
@@ -728,7 +749,7 @@ const getContentLength = (key: string, value: unknown, type: string): number => 
 
 const getGridSpanClass = (key: string, value: unknown, type: string): string => {
     // Long strings always take full width
-    if (type === "longString") {
+    if (type === "longString" || type === "url") {
         return "col-span-12";
     }
 
@@ -852,6 +873,7 @@ const getAllFieldsComputed = computed((): UnifiedField[] => {
             else if (typeof value === "number") type = "number";
             else if (typeof value === "boolean") type = "boolean";
             else if (isNumericString(value)) type = "number";
+            else if (isUrlString(value)) type = "url";
             else if (typeof value === "string" && isLongString(value)) type = "longString";
             else type = "shortString";
 
@@ -860,6 +882,7 @@ const getAllFieldsComputed = computed((): UnifiedField[] => {
             if (type === "number" || type === "boolean") priority = 2;
             else if (type === "shortString") priority = 3;
             else if (type === "vector") priority = 4;
+            else if (type === "url") priority = 5;
             else if (type === "longString") priority = 5;
 
             field = {

--- a/frontend/components/entities/EntityMetadata.vue
+++ b/frontend/components/entities/EntityMetadata.vue
@@ -419,10 +419,9 @@ const { isAuthenticated } = useAuth();
 const { mainTableDisplayName } = useAppConfiguration();
 
 const myHttpsLink = computed(() => {
-    // Check if the UUID exists on the entity
-    if (!props.entity?.uuid) return '';
+
     // Construct the link (Replace with your actual domain/path if needed)
-    return `https://fcc-physics-events.web.cern.ch/?q=${props.entity.uuid}`;
+    return `https://fcc-physics-events.web.cern.ch/?q=uuid%3D${props.entity.uuid}`;
 });
 
 const copyLinkToClipboard = () => {

--- a/frontend/components/entities/EntityMetadata.vue
+++ b/frontend/components/entities/EntityMetadata.vue
@@ -129,6 +129,22 @@
                         </UButton>
                     </UTooltip>
 
+                    <!-- Link button -->
+                    <UTooltip
+                        text="Copy link to this record"
+                        :popper="{ placement: 'top' }"
+                    >
+                        <UButton
+                            icon="i-heroicons-link"
+                            class="text-neutral-600 cursor-pointer hover:text-neutral-800 hover:bg-neutral-100"
+                            variant="ghost"
+                            size="xs"
+                            @click="copyLinkToClipboard"
+                        >
+                            Link
+                        </UButton>
+                    </UTooltip>
+
                     <!-- Edit button -->
                     <UButton
                         icon="i-heroicons-pencil"
@@ -401,6 +417,18 @@ const { formatFieldName, formatSizeInGiB, copyToClipboard, isStatusField, getSta
     useUtils();
 const { isAuthenticated } = useAuth();
 const { mainTableDisplayName } = useAppConfiguration();
+
+const myHttpsLink = computed(() => {
+    // Check if the UUID exists on the entity
+    if (!props.entity?.uuid) return '';
+    // Construct the link (Replace with your actual domain/path if needed)
+    return `https://fcc-physics-events.web.cern.ch/?q=${props.entity.uuid}`;
+});
+
+const copyLinkToClipboard = () => {
+
+    copyToClipboard(myHttpsLink.value);
+};
 
 // Dynamic color system using CSS custom properties
 // Dark mode disabled for consistent mobile rendering

--- a/frontend/composables/entities/useEntitySearch.ts
+++ b/frontend/composables/entities/useEntitySearch.ts
@@ -198,7 +198,12 @@ export function useEntitySearch() {
             // For infinite scroll: use currentPage directly
             // For initial load: always start with page 1
             const pageToLoad = isInitialLoad ? 1 : scrollState.currentPage;
-            const queryToSend = searchQuery || "*";
+            // Removes "uuid=", spaces, and optional quotes before sending to API
+            const sanitizedQuery = searchQuery
+                .replace(/^uuid\s*=\s*['"]?/i, "")
+                .replace(/['"]?$/i, "")
+                .trim();
+            const queryToSend = sanitizedQuery || "*";
 
             const searchParams = {
                 query: queryToSend,

--- a/frontend/composables/entities/useEntitySearch.ts
+++ b/frontend/composables/entities/useEntitySearch.ts
@@ -198,12 +198,7 @@ export function useEntitySearch() {
             // For infinite scroll: use currentPage directly
             // For initial load: always start with page 1
             const pageToLoad = isInitialLoad ? 1 : scrollState.currentPage;
-            // Removes "uuid=", spaces, and optional quotes before sending to API
-            const sanitizedQuery = searchQuery
-                .replace(/^uuid\s*=\s*['"]?/i, "")
-                .replace(/['"]?$/i, "")
-                .trim();
-            const queryToSend = sanitizedQuery || "*";
+            const queryToSend = searchQuery || "*";
 
             const searchParams = {
                 query: queryToSend,


### PR DESCRIPTION
Adds a `config-url` metadata field to each dataset record at import time, 
linking it to its generator configuration card in the HEP-FCC/FCC-config repository.

- Generator is inferred from the dataset name's last path segment prefix 
  (wzp6/wz3p6 → Whizard, p8/pythia8 → Pythia8, kkmc → KKMC)
- Frontend renders config-url values as clickable external links with an 
  arrow-top-right icon, matching the existing link style